### PR TITLE
fix: add export maps, take out ESM from CJS entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,14 @@
     ".": {
       "import": "./dist/index_esm.js",
       "require": "./dist/index.js"
-    }
+    },
+    "./cwk-app-shell-define": "./dist/components/cwk-app-shell.js",
+    "./cwk-admin-sidebar-define": "./dist/components/cwk-admin-sidebar.js",
+    "./cwk-dialog-content-define": "./dist/components/cwk-dialog-content.js",
+    "./cwk-dialog-define": "./dist/components/cwk-dialog.js",
+    "./cwk-participant-frontend-capsule-define": "./dist/components/cwk-participant-frontend-capsule.js",
+    "./cwk-participant-backend-capsule-define": "./dist/components/cwk-participant-backend-capsule.js",
+    "./cwk-select-cookie-define": "./dist/components/cwk-select-cookie.js"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,16 @@
   "engines": {
     "node": ">=12.0.0"
   },
+  "exports": {
+    ".": {
+      "import": "./dist/index_esm.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
   "scripts": {
     "build": "rimraf dist && tsc -p tsconfig.node.json && tsc -p tsconfig.browser.json && ./copy-components",
     "build:watch": "rimraf dist && concurrently \"tsc -p tsconfig.node.json --watch\" \"tsc -p tsconfig.browser.json --watch\"",
@@ -42,10 +52,6 @@
     "dev server",
     "scaffold",
     "hot module reload"
-  ],
-  "files": [
-    "dist",
-    "src"
   ],
   "author": "Joren Broekema <joren.broekema@gmail.com>",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-export { setCapsule } from './components/setCapsule';
 export { generateKey } from './generate-key';
 export {
   noCacheMiddleware,

--- a/src/index_esm.ts
+++ b/src/index_esm.ts
@@ -1,0 +1,1 @@
+export { setCapsule } from './components/setCapsule';

--- a/src/middleware/jwt-middleware.ts
+++ b/src/middleware/jwt-middleware.ts
@@ -1,12 +1,10 @@
 import { Middleware } from 'koa';
 import _esmRequire from 'esm';
 import jwt from 'jsonwebtoken';
-import * as _module from 'module';
 import { WorkshopConfig } from '../types/CwkConfig';
 
 export const jwtMiddleware = (dir: string): Middleware => {
-  const _mod = (_module as unknown) as NodeModule;
-  const esmRequire = _esmRequire(_mod);
+  const esmRequire = _esmRequire(module);
   const workshop: WorkshopConfig = esmRequire(`${dir}/cwk.config.js`).default;
 
   return async (ctx, next) => {

--- a/src/plugins/admin-ui-plugin.ts
+++ b/src/plugins/admin-ui-plugin.ts
@@ -7,7 +7,10 @@ export function adminUIPlugin(dir: string): Plugin {
     name: 'admin-ui',
     transform(context: Context) {
       let rewrittenBody = context.body as string;
-      if (context.path === '/node_modules/code-workshop-kit/dist/components/cwk-admin-sidebar.js') {
+      if (
+        context.path === '/node_modules/code-workshop-kit/dist/components/cwk-admin-sidebar.js' ||
+        context.path === '/dist/components/cwk-admin-sidebar.js'
+      ) {
         const authToken = context.cookies.get('cwk_auth_token');
         if (!authToken || !verifyJWT(dir, authToken, context)) {
           rewrittenBody = '';

--- a/src/plugins/app-shell-plugin.ts
+++ b/src/plugins/app-shell-plugin.ts
@@ -16,7 +16,7 @@ export function appShellPlugin(cfg: WorkshopConfig): Plugin {
           context.url === `${pathRelativeToServer}/` ||
           context.url === `${pathRelativeToServer}/index.html`
         ) {
-          const browserPath = require.resolve('code-workshop-kit/dist/components/cwk-app-shell.js');
+          const browserPath = require.resolve('code-workshop-kit/cwk-app-shell-define');
           const appShellScript = `
             <script type="module">
               import '${browserPath}';

--- a/src/plugins/component-replacers-plugin.ts
+++ b/src/plugins/component-replacers-plugin.ts
@@ -13,7 +13,9 @@ export function componentReplacersPlugin(cfg: WorkshopConfig): Plugin {
       if (context.status === 200) {
         if (
           context.path === '/node_modules/code-workshop-kit/dist/components/SelectCookie.js' ||
-          context.path === '/node_modules/code-workshop-kit/dist/components/AppShell.js'
+          context.path === '/dist/components/SelectCookie.js' ||
+          context.path === '/node_modules/code-workshop-kit/dist/components/AppShell.js' ||
+          context.path === '/dist/components/AppShell.js'
         ) {
           rewrittenBody = rewrittenBody.replace(
             new RegExp('placeholder-import.js', 'g'),
@@ -24,9 +26,13 @@ export function componentReplacersPlugin(cfg: WorkshopConfig): Plugin {
         if (
           context.path ===
             '/node_modules/code-workshop-kit/dist/components/ParticipantFrontendCapsule.js' ||
+          context.path === '/dist/components/ParticipantFrontendCapsule.js' ||
           context.path ===
             '/node_modules/code-workshop-kit/dist/components/ParticipantTerminalCapsule.js' ||
-          context.path === '/node_modules/code-workshop-kit/dist/components/ParticipantCapsule.js'
+          context.path === '/dist/components/ParticipantCapsule.js' ||
+          context.path ===
+            '/node_modules/code-workshop-kit/dist/components/ParticipantCapsule.js' ||
+          context.path === '/dist/components/ParticipantCapsule.js'
         ) {
           let replacement = `${path.posix.resolve('/', pathRelativeToServer)}`;
           // remove trailing slash
@@ -36,7 +42,10 @@ export function componentReplacersPlugin(cfg: WorkshopConfig): Plugin {
           rewrittenBody = rewrittenBody.replace(new RegExp('%dir%', 'g'), replacement);
         }
 
-        if (context.path === '/node_modules/code-workshop-kit/dist/components/AppShell.js') {
+        if (
+          context.path === '/node_modules/code-workshop-kit/dist/components/AppShell.js' ||
+          context.path === '/dist/components/AppShell.js'
+        ) {
           rewrittenBody = rewrittenBody.replace(
             new RegExp("this.mode = 'iframe';", 'g'),
             `this.mode = '${cfg.targetOptions?.mode || 'iframe'}';`,

--- a/src/plugins/missing-index-html-plugin.ts
+++ b/src/plugins/missing-index-html-plugin.ts
@@ -60,7 +60,7 @@ export function missingIndexHtmlPlugin(cfg: WorkshopConfig): Plugin {
               </head>
               <body>
                 <script type="module">
-                  import { setCapsule } from 'code-workshop-kit/dist/components/setCapsule.js';
+                  import { setCapsule } from 'code-workshop-kit';
                   setCapsule('${participantFolder}', { target: '${cfg.target}' });
                 </script>
               </body>

--- a/src/plugins/ws-port-plugin.ts
+++ b/src/plugins/ws-port-plugin.ts
@@ -8,10 +8,13 @@ export function wsPortPlugin(port: number): Plugin {
       let rewrittenBody = context.body as string;
       if (
         context.path === '/node_modules/code-workshop-kit/dist/components/AdminSidebar.js' ||
+        context.path === '/dist/components/AdminSidebar.js' ||
         context.path ===
           '/node_modules/code-workshop-kit/dist/components/ParticipantFrontendCapsule.js' ||
+        context.path === '/dist/components/ParticipantFrontendCapsule.js' ||
         context.path ===
-          '/node_modules/code-workshop-kit/dist/components/ParticipantTerminalCapsule.js'
+          '/node_modules/code-workshop-kit/dist/components/ParticipantTerminalCapsule.js' ||
+        context.path === '/dist/components/ParticipantTerminalCapsule.js'
       ) {
         rewrittenBody = rewrittenBody.replace(new RegExp('%websocketport%', 'g'), `${port}`);
       }

--- a/src/scaffold-files.ts
+++ b/src/scaffold-files.ts
@@ -4,7 +4,6 @@ import commandLineArgs from 'command-line-args';
 import _esmRequire from 'esm';
 import fs from 'fs';
 import glob from 'glob';
-import * as _module from 'module';
 import path from 'path';
 import { WorkshopConfig } from './types/CwkConfig';
 
@@ -101,8 +100,7 @@ export const scaffold = async (_opts: ScaffoldOptions): Promise<void> => {
       ({ workshop } = opts);
     } else {
       // We know we are in NodeJS so force module typecast to NodeModule
-      const _mod = (_module as unknown) as NodeModule;
-      const esmRequire = _esmRequire(_mod);
+      const esmRequire = _esmRequire(module);
       workshop = esmRequire(pathToWorkshop).default;
     }
 

--- a/src/utils/verifyJWT.ts
+++ b/src/utils/verifyJWT.ts
@@ -1,6 +1,5 @@
 import _esmRequire from 'esm';
 import jwt from 'jsonwebtoken';
-import * as _module from 'module';
 import { Context } from 'koa';
 
 export const verifyJWT = (
@@ -8,8 +7,7 @@ export const verifyJWT = (
   authToken: string,
   ctx: Context,
 ): string | Record<string, unknown> => {
-  const _mod = (_module as unknown) as NodeModule;
-  const esmRequire = _esmRequire(_mod);
+  const esmRequire = _esmRequire(module);
   const workshop = esmRequire(`${dir}/cwk.config.js`).default;
 
   let authed;

--- a/tsconfig.browser.json
+++ b/tsconfig.browser.json
@@ -6,6 +6,6 @@
     "rootDir": "./src",
     "outDir": "dist"
   },
-  "include": ["src/components/**/*.ts"],
+  "include": ["src/components/**/*.ts", "src/index_esm.ts"],
   "exclude": []
 }


### PR DESCRIPTION
For tools supporting export maps like later versions of NodeJS / @web/dev-server this should not be breaking.
If you're on early versions, you can still import setCapsule, but from code-workshop-kit/dist/components/setCapsule.js directly.